### PR TITLE
Add first version of PTXIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# Build dir
+build/
+
+# .cache dir
+.cache/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/llvm-project"]
 	path = external/llvm-project
 	url = https://github.com/llvm/llvm-project.git
+[submodule "external/googletest"]
+	path = external/googletest
+	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.23)
+project(compiler LANGUAGES CXX)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(POLICY CMP0116)
+  cmake_policy(SET CMP0116 OLD)
+endif()
+
+set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)
+set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include)
+set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
+set(MLIR_INCLUDE_DIRS "${MLIR_INCLUDE_DIR};${MLIR_GENERATED_INCLUDE_DIR}")
+
+set(VISA_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(VISA_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+set(LLVM_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-project/llvm")
+
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+
+list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
+list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
+set(MLIR_TABLEGEN_EXE mlir-tblgen)
+
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
+
+add_subdirectory(lib)

--- a/configure.sh
+++ b/configure.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+cmake -GNinja -Bbuild \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DLLVM_ENABLE_PROJECTS=mlir \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -DLLVM_EXTERNAL_PROJECTS=compiler \
+    -DLLVM_EXTERNAL_COMPILER_SOURCE_DIR=`pwd` \
+    -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
+    -DLLVM_TARGETS_TO_BUILD="X86;NVPTX;AMDGPU" \
+    external/llvm-project/llvm

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(ptx)

--- a/lib/ir/CFG.h
+++ b/lib/ir/CFG.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <memory>
+
+/**
+ * @class BasicBlock
+ * @brief This class represents a maximal length sequence
+ *        of straightline code.
+ *
+ */
+class BasicBlock {
+public:
+  using Ptr = std::unique_ptr<BasicBlock>;
+};
+
+
+/**
+ * @class Graph
+ * @brief This class represents the control flow graph.
+ *
+ */
+class ControlFlowGraph {
+public:
+  using Ptr = std::unique_ptr<ControlFlowGraph>;
+};

--- a/lib/ir/CMakeLists.txt
+++ b/lib/ir/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(PTXIR INTERFACE)
+target_include_directories(PTXIR INTERFACE ${CMAKE_CURRENT_LIST_DIR})

--- a/lib/ir/PTXIR.h
+++ b/lib/ir/PTXIR.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <vector>
+#include <string_view>
+#include "Value.h"
+#include "CFG.h"
+
+/**
+ * @class Operand
+ * @brief This class represents the operands of a PTX Instruction.
+ *
+ */
+class PTXOperand {
+public:
+  enum Kind {
+    Register,
+    Immediate,
+    Expression,
+  };
+  PTXOperand() = delete;
+  PTXOperand(std::string_view name_, Kind kind_) :
+    name(name_), kind(kind_) {}
+  ~PTXOperand() {}
+
+private:
+  std::string_view name;
+  Kind kind;
+};
+
+/**
+ * @class Instruction
+ * @brief This class represents a PTX Instruction.
+ *
+ */
+class PTXInstruction {
+  std::string_view name;
+  std::vector<PTXOperand> operands;
+public:
+  PTXInstruction() = delete;
+  PTXInstruction(std::string_view name_, const std::vector<PTXOperand> &operands_) :
+    name(name_), operands(operands_) {}
+  ~PTXInstruction() {}
+};
+
+
+/**
+ * @class PTXDirective
+ * @brief A PTX Directive starts with a '.'
+ *
+ */
+class PTXDirective {
+  std::string_view name;
+public:
+  PTXDirective() = delete;
+};
+
+
+/**
+ * @class PTXKernel
+ * @brief A PTX Kernel has a name, takes in 0 or more arguments
+ *        and has a body containing the computation.
+ *
+ */
+class PTXKernel {
+  std::string_view name;
+  std::vector<Value> arguments;
+  ControlFlowGraph::Ptr body;
+public:
+  using Ptr = std::unique_ptr<PTXKernel>;
+
+};
+
+
+/**
+ * @class PTXProgram
+ * @brief A PTXProgram is composed of multiple kernels,
+ *        global directives and variables.
+ *
+ */
+class PTXProgram {
+  std::vector<PTXKernel::Ptr> kernels;
+  std::string_view name;
+public:
+  PTXProgram(std::string_view name_) : name(name_) {}
+  void push_back(PTXKernel::Ptr kernel) {
+    kernels.push_back(kernel);
+  }
+};

--- a/lib/ir/SymbolTable.h
+++ b/lib/ir/SymbolTable.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "Value.h"
+#include <unordered_map>
+#include <string_view>
+#include <optional>
+
+/**
+ * @class SymbolTable
+ * @brief This class defines the symbol table.
+ *
+ */
+class SymbolTable {
+  std::unordered_map<std::string_view, Value> table;
+public:
+
+  /**
+   * @brief Looks up the symbol in the symbol table. Returns
+   *        corresponding value if found, else none.
+   *
+   * @param symbol : Symbol to be searched
+   */
+  std::optional<Value> lookup(std::string_view symbol) const {
+    if (table.contains(symbol)) {
+      return table[symbol];
+    }
+    return {};
+  }
+
+  /**
+   * @brief Stores the value corresponding to symbol in the
+   *        symbol table.
+   *
+   * @param symbol : Symbol to be inserted into the table
+   * @param value : Value corresponding to the symbol
+   */
+  void insert(std::string_view symbol, Value value) {
+    table[symbol] = value;
+  }
+
+};

--- a/lib/ir/Value.h
+++ b/lib/ir/Value.h
@@ -1,0 +1,21 @@
+#pragma once
+
+/**
+ * @class Type
+ * @brief This class represents the type of a value
+ *
+ */
+class Type {
+public:
+};
+
+/**
+ * @class Value
+ * @brief This class represents a value in the CFG
+ *
+ */
+class Value {
+  Type type;
+public:
+  Type getType() const { return type; }
+};


### PR DESCRIPTION
This is a first attempt at defining the data structures that would be used when parsing PTX and convert PTX to LLVM IR.
The current thought is that we have a high-level PTXProgram that contains the entire PTX file being parsed. Each PTXProgram is then composed of a series of PTXKernels with some global directives and variables. Each PTXKernel is represented by a name, args and a CFG representing the body of the kernel. The CFG itself is composed of basic blocks where each block consists of group of PTX instructions. Each PTX instruction has an name/opcode and PTXOperands.
Would appreciate any feedback! Thanks!