### PR TITLE
Add handling of nvvm intrinsics

### DIFF
--- a/include/conversion/RaiseToLLVM.h
+++ b/include/conversion/RaiseToLLVM.h
@@ -7,15 +7,15 @@
 class PTXToLLVMConverter {
   std::unique_ptr<llvm::Module> module;
   llvm::LLVMContext &context;
+  PTXProgram &program;
 public:
-  PTXToLLVMConverter(std::string_view name, llvm::LLVMContext &context);
+  PTXToLLVMConverter(PTXProgram &program, llvm::LLVMContext &context);
   ~PTXToLLVMConverter() {}
   void AddFunction(PTXKernel &kernel);
   std::string printModule() const;
   llvm::Module *getModule() const {
     return module.get();
   }
-  llvm::Module *RaiseToLLVM(PTXProgram &program,
-                            llvm::LLVMContext &context);
+  llvm::Module *RaiseToLLVM();
 };
 

--- a/include/ir/SymbolTable.h
+++ b/include/ir/SymbolTable.h
@@ -10,12 +10,12 @@
  * @brief This class defines the symbol table.
  *
  */
-class SymbolTable {
-  std::unordered_map<std::string_view, Value> table;
+class PTXSymbolTable {
+  std::unordered_map<std::string_view, PTXValue> table;
 public:
 
-  SymbolTable() {}
-  ~SymbolTable() {}
+  PTXSymbolTable() {}
+  ~PTXSymbolTable() {}
 
   /**
    * @brief Looks up the symbol in the symbol table. Returns
@@ -23,7 +23,7 @@ public:
    *
    * @param symbol : Symbol to be searched
    */
-  std::optional<Value> lookup(std::string_view symbol) const {
+  std::optional<PTXValue> lookup(std::string_view symbol) const {
     if (table.contains(symbol)) {
       return table.at(symbol);
     }
@@ -37,7 +37,7 @@ public:
    * @param symbol : Symbol to be inserted into the table
    * @param value : Value corresponding to the symbol
    */
-  void insert(std::string_view symbol, Value value) {
+  void insert(std::string_view symbol, PTXValue value) {
     table.emplace(std::make_pair(symbol, value));
   }
 

--- a/include/ir/Value.h
+++ b/include/ir/Value.h
@@ -2,16 +2,18 @@
 
 #include <string_view>
 
+class PTXInstruction;
+
 /**
  * @class Type
  * @brief This class represents the type of a value
  *
  */
-class Type {
+class PTXType {
   std::string_view type;
 public:
-  Type() = delete;
-  Type(std::string_view type_) : type(type_) {}
+  PTXType() {}
+  PTXType(std::string_view type_) : type(type_) {}
 };
 
 /**
@@ -19,13 +21,27 @@ public:
  * @brief This class represents a value in the CFG
  *
  */
-class Value {
+class PTXValue {
   std::string_view symbol;
-  Type type;
+  std::vector<PTXInstruction *> uses;
+  PTXInstruction *def;
+  PTXType type;
 public:
-  Value() = delete;
-  Value(std::string_view symbol_, Type type_) :
+  PTXValue() {}
+  PTXValue(std::string_view symbol_, PTXType type_) :
     symbol(symbol_), type(type_) {}
-  Type getType() const { return type; }
+  PTXType getType() const { return type; }
   std::string_view getSymbol() const { return symbol; }
+  void addUse(PTXInstruction *instr) {
+    uses.push_back(instr);
+  }
+  std::vector<PTXInstruction *> &getUses() {
+    return uses;
+  }
+  void addDefiningInstruction(PTXInstruction *instr) {
+    def = instr;
+  }
+  PTXInstruction *getDefiningInstruction() {
+    return def;
+  }
 };

--- a/lib/conversion/CMakeLists.txt
+++ b/lib/conversion/CMakeLists.txt
@@ -5,4 +5,5 @@ target_link_libraries(PTXToLLVMConversion
   PTXIR
   LLVMCore
   LLVMSupport
+  LLVMTransformUtils
 )

--- a/lib/conversion/RaiseToLLVM.cpp
+++ b/lib/conversion/RaiseToLLVM.cpp
@@ -1,15 +1,54 @@
 #include "conversion/RaiseToLLVM.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/IntrinsicsNVPTX.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
+#include <iostream>
 
 using namespace llvm;
 
-PTXToLLVMConverter::PTXToLLVMConverter(std::string_view name, LLVMContext &context_) : context(context_) {
-    module = std::make_unique<Module>(name, context);
+PTXToLLVMConverter::PTXToLLVMConverter(PTXProgram &program_, LLVMContext &context_) : context(context_), program(program_) {
+    module = std::make_unique<Module>(program.getName(), context);
     // TODO: Do we need to hardcode these values or can they be deduced from PTX?
     module->setDataLayout("e-i64:64-i128:128-v16:16-v32:32-n16:32:64");
     module->setTargetTriple("nvptx-nvidia-cuda");
 }
 
 void PTXToLLVMConverter::AddFunction(PTXKernel &kernel) {
+  IRBuilder<> Builder(context);
+  auto retTy = Type::getVoidTy(context);
+  auto FuncTy = FunctionType::get(retTy, false);
+  Function *F = Function::Create(FuncTy,
+                                 Function::ExternalLinkage,
+                                 kernel.getName(),
+                                 module.get());
+  // TODO: Are all of these required?
+  F->addFnAttr(Attribute::Convergent);
+  F->addFnAttr(Attribute::MustProgress);
+  F->addFnAttr(Attribute::NoInline);
+  F->addFnAttr(Attribute::NoRecurse);
+  F->addFnAttr(Attribute::NoUnwind);
+  F->addFnAttr(Attribute::OptimizeNone);
+  BasicBlock *BB = BasicBlock::Create(context, "", F);
+  Builder.SetInsertPoint(BB);
+  for (auto block : kernel.getBody().getBlocks()) {
+    for (auto instr : block.getInstructions()) {
+      std::cout << "Processing ... " << instr.getName() << std::endl;
+      if ((instr.getName() == "mov.u32") && (instr.getOperand(1)))  {
+        CallInst *call;
+        Function *FF;
+        if (instr.getOperand(1)->getName() == "%ctaid.x") {
+          FF = llvm::Intrinsic::getDeclaration(module.get(), llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_x);
+        }
+        if (instr.getOperand(1)->getName() == "%ntid.x") {
+          FF = llvm::Intrinsic::getDeclaration(module.get(), llvm::Intrinsic::nvvm_read_ptx_sreg_ntid_x);
+        }
+        if (instr.getOperand(1)->getName() == "%tid.x") {
+          FF = llvm::Intrinsic::getDeclaration(module.get(), llvm::Intrinsic::nvvm_read_ptx_sreg_tid_x);
+        }
+        call = Builder.CreateCall(FF);
+      }
+    }
+  }
 }
 
 std::string PTXToLLVMConverter::printModule() const {
@@ -20,10 +59,9 @@ std::string PTXToLLVMConverter::printModule() const {
   return str;
 }
 
-Module *PTXToLLVMConverter::RaiseToLLVM(PTXProgram &program, LLVMContext &context) {
-  PTXToLLVMConverter converter(program.getName(), context);
+Module *PTXToLLVMConverter::RaiseToLLVM() {
   for (auto kernel : program.getKernels()) {
-    converter.AddFunction(kernel);
+    AddFunction(kernel);
   }
-  return converter.getModule();
+  return getModule();
 }

--- a/lib/ir/PTXIR.cpp
+++ b/lib/ir/PTXIR.cpp
@@ -1,5 +1,43 @@
 #include "ir/PTXIR.h"
+#include <iostream>
 
-PTXKernel::PTXKernel(std::string_view name_, std::vector<Value> &arguments_,
-          ControlFlowGraph &body_) :
+PTXKernel::PTXKernel(std::string_view name_, std::vector<PTXValue> &arguments_,
+          PTXControlFlowGraph &body_) :
          name(name_), arguments(arguments_), body(body_) {}
+
+void PTXControlFlowGraph::computeDefUseChain() {
+  for (auto block : blocks) {
+    block.computeDefUseChain();
+  }
+}
+
+void PTXBasicBlock::computeDefUseChain() {
+  for (auto inst : instructions) {
+    computeDefUseChain(inst);
+  }
+}
+
+void PTXBasicBlock::computeDefUseChain(PTXInstruction &inst) {
+  if (!symbolTable)
+    return;
+  int i = 0;
+  for (auto operand : inst.getOperands()) {
+    auto name = operand.getName();
+    auto found = symbolTable->lookup(name);
+    PTXValue v;
+    if (!found) {
+      v = PTXValue(name, inst.getOperandType());
+    } else {
+      v = *found;
+    }
+    // TODO:Does this work for all PTX instructions?
+    if (i == 0) {
+      v.addDefiningInstruction(&inst);
+    } else {
+      v.addUse(&inst);
+    }
+    if (!found)
+      symbolTable->insert(name, v);
+    i++;
+  }
+}

--- a/test/conversion/RaiseToLLVM_test.cpp
+++ b/test/conversion/RaiseToLLVM_test.cpp
@@ -3,20 +3,45 @@
 #include "llvm/IR/Module.h"
 
 
-TEST(RaiseToLLVMTest, SimpleTest) {
+TEST(RaiseToLLVMTest, SimpleKernel) {
   llvm::LLVMContext context;
   PTXProgram program("kernel");
-  std::vector<Value> args;
-  ControlFlowGraph body;
+  std::vector<PTXValue> args;
+  PTXControlFlowGraph body;
+  PTXBasicBlock block;
+  PTXInstruction instr0("mov.u32", {PTXOperand("%r1"), PTXOperand("%ctaid.x")});
+  PTXInstruction instr1("mov.u32", {PTXOperand("%r2"), PTXOperand("%ntid.x")});
+  PTXInstruction instr2("mov.u32", {PTXOperand("%r4"), PTXOperand("%tid.x")});
+  block.push_back(instr0);
+  block.push_back(instr1);
+  block.push_back(instr2);
+  body.push_back(block);
+  body.computeDefUseChain();
   PTXKernel kernel{"add", args, body};
   program.push_back(kernel);
-  PTXToLLVMConverter converter("kernel", context);
-  converter.RaiseToLLVM(program, context);
+  PTXToLLVMConverter converter(program, context);
+  converter.RaiseToLLVM();
   auto moduleStr = converter.printModule();
+  std::cout << moduleStr << std::endl;
   std::string expectedStr =
     "; ModuleID = 'kernel'\n"
     "source_filename = \"kernel\"\n"
     "target datalayout = \"e-i64:64-i128:128-v16:16-v32:32-n16:32:64\"\n"
-    "target triple = \"nvptx-nvidia-cuda\"\n";
+    "target triple = \"nvptx-nvidia-cuda\"\n\n"
+    "; Function Attrs: convergent mustprogress noinline norecurse nounwind optnone\n"
+    "define void @add() #0 {\n"
+    "  %1 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()\n"
+    "  %2 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()\n"
+    "  %3 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()\n"
+    "}\n\n"
+    "; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn\n"
+    "declare i32 @llvm.nvvm.read.ptx.sreg.ctaid.x() #1\n\n"
+    "; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn\n"
+    "declare i32 @llvm.nvvm.read.ptx.sreg.ntid.x() #1\n\n"
+    "; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn\n"
+    "declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() #1\n\n"
+    "attributes #0 = { convergent mustprogress noinline norecurse nounwind optnone }\n"
+    "attributes #1 = { nocallback nofree nosync nounwind readnone speculatable willreturn }\n"
+    ;
   EXPECT_EQ(moduleStr, expectedStr);
 }

--- a/test/ir/PTXIR_test.cpp
+++ b/test/ir/PTXIR_test.cpp
@@ -3,5 +3,5 @@
 
 TEST(PTXIRTest, PTXOperand) {
   EXPECT_NO_THROW(
-    std::make_unique<PTXOperand>("%rd2", PTXOperand::Kind::Register));
+    std::make_unique<PTXOperand>("%rd2"));
 }

--- a/test/ir/SymbolTable_test.cpp
+++ b/test/ir/SymbolTable_test.cpp
@@ -2,18 +2,18 @@
 #include "ir/SymbolTable.h"
 
 TEST(SymbolTableTest, AddEntry) {
-  auto symTable = std::make_unique<SymbolTable>();
+  auto symTable = std::make_unique<PTXSymbolTable>();
   EXPECT_EQ(symTable->size(), 0);
-  Type type("i8");
-  auto v = Value("a", type);
+  PTXType type("i8");
+  auto v = PTXValue("a", type);
   symTable->insert("a", v);
   EXPECT_EQ(symTable->size(), 1);
 }
 
 TEST(SymbolTableTest, LookupEntry) {
-  auto symTable = std::make_unique<SymbolTable>();
-  Type type("i8");
-  auto v = Value("a", type);
+  auto symTable = std::make_unique<PTXSymbolTable>();
+  PTXType type("i8");
+  auto v = PTXValue("a", type);
   symTable->insert("a", v);
   auto shouldBeFound = symTable->lookup("a");
   if (!shouldBeFound) {

--- a/test/ir/Value_test.cpp
+++ b/test/ir/Value_test.cpp
@@ -2,6 +2,6 @@
 #include "ir/Value.h"
 
 TEST(ValueTest, CreateValue) {
-  EXPECT_NO_THROW(Value("a", Type("i8")));
+  EXPECT_NO_THROW(PTXValue("a", PTXType("i8")));
 }
 


### PR DESCRIPTION
This patch adds code to handle emitting instrinsics
for ctaid.x, ntid.x, tid.x. The unit test has been updated
to test this.

We also add computation of def-use chains for future
analysis.