### PR TITLE
Add type inference to determine types of values

### DIFF
--- a/include/conversion/RaiseToLLVM.h
+++ b/include/conversion/RaiseToLLVM.h
@@ -3,11 +3,16 @@
 #include "ir/PTXIR.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/IRBuilder.h"
+#include "conversion/TypeInference.h"
 
 class PTXToLLVMConverter {
   std::unique_ptr<llvm::Module> module;
   llvm::LLVMContext &context;
   PTXProgram &program;
+  std::unique_ptr<PTXTypeInference> typeInferrer;
+  void performTypeInference(PTXBasicBlock &block);
+  llvm::Type *mapType(std::string_view str);
 public:
   PTXToLLVMConverter(PTXProgram &program, llvm::LLVMContext &context);
   ~PTXToLLVMConverter() {}

--- a/include/conversion/TypeInference.h
+++ b/include/conversion/TypeInference.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "ir/PTXIR.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/IRBuilder.h"
+#include <optional>
+
+class PTXTypeInference {
+public:
+  PTXTypeInference() = delete;
+  PTXTypeInference(llvm::LLVMContext &context_) : context(context_) {}
+  void doTypeInference(PTXControlFlowGraph &cfg);
+  void constrainType(std::string_view name, std::string_view type);
+  void applyConstraints(PTXInstruction &instr);
+  std::optional<std::string_view> getType(std::string_view symbol);
+private:
+  llvm::LLVMContext &context;
+  std::unordered_map<std::string_view, std::string_view> typeMap;
+  void substituteType();
+};

--- a/include/ir/PTXIR.h
+++ b/include/ir/PTXIR.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <optional>
 #include <string_view>
+#include <string>
 #include "ir/Value.h"
 #include "ir/SymbolTable.h"
 
@@ -38,6 +39,9 @@ public:
     name(name_), operands(operands_) {}
   ~PTXInstruction() {}
   std::string_view getName() const { return name; }
+  size_t getNumOperands() const {
+    return operands.size();
+  }
   std::optional<PTXOperand> getOperand(size_t idx) {
     if (idx < operands.size()) return operands[idx];
     return {};
@@ -47,6 +51,14 @@ public:
   }
   std::string_view getOperandType() {
     return name.substr(name.size() - 3);
+  }
+  std::string print() {
+    std::string str = std::string(name) + " ";
+    for (size_t i = 0; i < operands.size() - 1; i++) {
+      str += std::string(operands[i].getName()) + ", ";
+    }
+    str += std::string(operands[operands.size() - 1].getName()) + ";\n";
+    return str;
   }
 };
 
@@ -128,6 +140,7 @@ public:
             PTXControlFlowGraph &body_);
   std::string_view getName() const { return name; }
   PTXControlFlowGraph &getBody() { return body; }
+  std::vector<PTXValue> &getArguments() { return arguments; }
 };
 
 

--- a/lib/conversion/CMakeLists.txt
+++ b/lib/conversion/CMakeLists.txt
@@ -1,4 +1,7 @@
-set(SRC RaiseToLLVM.cpp)
+set(SRC
+  RaiseToLLVM.cpp
+  TypeInference.cpp
+)
 add_library(PTXToLLVMConversion ${SRC})
 target_link_libraries(PTXToLLVMConversion
   PUBLIC

--- a/lib/conversion/TypeInference.cpp
+++ b/lib/conversion/TypeInference.cpp
@@ -1,0 +1,172 @@
+#include "conversion/TypeInference.h"
+#include <iostream>
+#include <algorithm>
+
+static std::vector<std::string_view> tokenize(std::string_view inst) {
+  std::vector<std::string_view> tokens;
+  size_t begin{0}, end{0};
+  for (size_t i = 0; i < inst.size(); i++) {
+    if (inst[i] == '.') {
+      end = i;
+      tokens.push_back(inst.substr(begin, end - begin));
+      begin = end + 1;
+    }
+    if (i == inst.size() - 1) {
+      tokens.push_back(inst.substr(begin, inst.size() -  begin));
+    }
+  }
+  return tokens;
+}
+
+static std::string_view getPrefix(std::vector<std::string_view> &tokens) {
+  return tokens[0];
+}
+
+// Assumes last token can be used to determine the type
+static inline std::string_view getInstrType(std::vector<std::string_view> &tokens) {
+  return tokens.back();
+}
+
+static inline bool isLoadInstruction(std::vector<std::string_view> &tokens) {
+  return getPrefix(tokens) == "ld";
+}
+
+static inline bool isStoreInstruction(std::vector<std::string_view> &tokens) {
+  return getPrefix(tokens) == "st";
+}
+
+static inline bool isConvertInstruction(std::vector<std::string_view> &tokens) {
+  return getPrefix(tokens) == "cvta";
+}
+
+static inline bool isBinaryInstruction(std::vector<std::string_view> &tokens) {
+  auto prefix = getPrefix(tokens);
+  return ((prefix == "mul") || (prefix == "add") || (prefix == "shl"));
+}
+
+void PTXTypeInference::constrainType(std::string_view name, std::string_view type) {
+  if (typeMap.count(name)) {
+    assert(name + "already present in type map!\n");
+  }
+  typeMap.insert({name, type});
+}
+
+static inline std::string_view getAddress(std::string_view str) {
+  return str.substr(1, str.size() - 2);
+}
+
+static inline bool isDereference(std::string_view str) {
+  return (str[0] == '[') && (str.back() == ']');
+}
+
+static std::string_view getPointerType(std::string_view str) {
+  if (str == "f32") return "ptr_f32";
+  if (str == "ptr_f32") return "ptr_ptr_f32";
+  if (str == "u32") return "ptr_u32";
+  if (str == "u64") return "ptr_u64";
+  assert("Not supported type" + str);
+  return "";
+}
+
+static std::string_view getElementType(std::string_view str) {
+  return str.substr(4, str.size() - 4);
+}
+
+static void propagateOperandTypes(std::vector<std::string_view> &tokens,
+                                  std::vector<std::string_view> &operandTypes,
+                                  std::vector<size_t> &constrainedIndices) {
+  if (constrainedIndices.empty()) return;
+  if (isLoadInstruction(tokens)) {
+    if (constrainedIndices[0] == 0) {
+      operandTypes[1] = getPointerType(operandTypes[0]);
+    } else {
+      operandTypes[0] = getElementType(operandTypes[1]);
+    }
+  }
+  if (isStoreInstruction(tokens)) {
+    if (constrainedIndices[0] == 0) {
+      operandTypes[1] = getElementType(operandTypes[0]);
+    } else {
+      operandTypes[0] = getPointerType(operandTypes[1]);
+    }
+  }
+  if (isConvertInstruction(tokens) || isBinaryInstruction(tokens)) {
+    // Assumes all types are identical
+    for (size_t i = 0; i < operandTypes.size(); i++) {
+      operandTypes[i] = operandTypes[constrainedIndices[0]];
+    }
+  }
+}
+
+void PTXTypeInference::applyConstraints(PTXInstruction &instr) {
+  auto tokens = tokenize(instr.getName());
+  std::function<void (size_t, std::string_view)> typeConstraint;
+  std::string_view instrType = getInstrType(tokens);
+  std::vector<std::string_view> operandTypes;
+  operandTypes.resize(instr.getNumOperands(), std::string_view());
+  std::vector<size_t> constrainedIndices;
+  for (size_t i = 0; i < instr.getNumOperands(); i++) {
+    if (instr.getOperand(i)) {
+      auto operandName = instr.getOperand(i)->getName();
+      if (isDereference(operandName))
+        operandName = getAddress(operandName);
+      if (typeMap.contains(operandName)) {
+        operandTypes[i] = typeMap[operandName];
+        constrainedIndices.push_back(i);
+      }
+    }
+  }
+  propagateOperandTypes(tokens, operandTypes, constrainedIndices);
+  if (isLoadInstruction(tokens) || isStoreInstruction(tokens)) {
+    size_t pointerIndex = isLoadInstruction(tokens) ? 1 : 0;
+    size_t nonPointerIndex = pointerIndex == 0 ? 1 : 0;
+    if (constrainedIndices.empty()) {
+      typeConstraint = [instrType, pointerIndex, nonPointerIndex, this]
+                       (size_t index, std::string_view name) {
+        if (index == nonPointerIndex) {
+          constrainType(name, instrType);
+        }
+        if (index == pointerIndex) {
+          constrainType(getAddress(name), getPointerType(instrType));
+        }
+      };
+    } else {
+      typeConstraint = [pointerIndex, nonPointerIndex, operandTypes, this]
+                       (size_t index, std::string_view name) {
+        if (index == nonPointerIndex)
+            constrainType(name, operandTypes[index]);
+        if (index == pointerIndex)
+            constrainType(getAddress(name), operandTypes[index]);
+      };
+    }
+  }
+  if (isConvertInstruction(tokens) || isBinaryInstruction(tokens)) {
+    if (!constrainedIndices.empty()) {
+      instrType = operandTypes[constrainedIndices[0]];
+    }
+    typeConstraint = [instrType, this](size_t index, std::string_view name) {
+        constrainType(name, instrType);
+    };
+  }
+  if (typeConstraint) {
+    for (size_t i = 0; i < instr.getNumOperands(); i++) {
+      if (instr.getOperand(i))
+        typeConstraint(i, instr.getOperand(i)->getName());
+    }
+  }
+}
+
+void PTXTypeInference::doTypeInference(PTXControlFlowGraph &cfg) {
+  for (auto block : cfg.getBlocks()) {
+    for (auto inst : llvm::reverse(block.getInstructions())) {
+      applyConstraints(inst);
+    }
+  }
+}
+
+std::optional<std::string_view> PTXTypeInference::getType(std::string_view symbol) {
+  if (typeMap.contains(symbol)) {
+    return typeMap.at(symbol);
+  }
+  return {};
+}

--- a/test/conversion/RaiseToLLVM_test.cpp
+++ b/test/conversion/RaiseToLLVM_test.cpp
@@ -2,19 +2,60 @@
 #include "conversion/RaiseToLLVM.h"
 #include "llvm/IR/Module.h"
 
+#define DEFINE(i, x, y) \
+  { \
+    PTXInstruction instr(i, {PTXOperand(x), PTXOperand(y)}); \
+    block.push_back(instr); \
+  }
+
+#define DEFINE3(i, x, y, z) \
+  { \
+    PTXInstruction instr(i, {PTXOperand(x), PTXOperand(y), PTXOperand(z)}); \
+    block.push_back(instr); \
+  }
+
 
 TEST(RaiseToLLVMTest, SimpleKernel) {
   llvm::LLVMContext context;
   PTXProgram program("kernel");
   std::vector<PTXValue> args;
+  args.push_back(PTXValue("_Z3addPKfS0_Pf_param_0", PTXType("u64")));
+  args.push_back(PTXValue("_Z3addPKfS0_Pf_param_1", PTXType("u64")));
+  args.push_back(PTXValue("_Z3addPKfS0_Pf_param_2", PTXType("u64")));
   PTXControlFlowGraph body;
   PTXBasicBlock block;
-  PTXInstruction instr0("mov.u32", {PTXOperand("%r1"), PTXOperand("%ctaid.x")});
-  PTXInstruction instr1("mov.u32", {PTXOperand("%r2"), PTXOperand("%ntid.x")});
-  PTXInstruction instr2("mov.u32", {PTXOperand("%r4"), PTXOperand("%tid.x")});
-  block.push_back(instr0);
-  block.push_back(instr1);
-  block.push_back(instr2);
+	DEFINE("mov.u64",	"%SPL", "__local_depot6");
+	DEFINE("cvta.local.u64", "%SP", "%SPL");
+	DEFINE("ld.param.u64", "%rd3", "[_Z3addPKfS0_Pf_param_2]");
+	DEFINE("ld.param.u64", "%rd2", "[_Z3addPKfS0_Pf_param_1]");
+	DEFINE("ld.param.u64", "%rd1", "[_Z3addPKfS0_Pf_param_0]");
+	DEFINE("cvta.to.global.u64", 	"%rd4", "%rd3");
+	DEFINE("cvta.global.u64", 	"%rd5", "%rd4");
+	DEFINE("cvta.to.global.u64", 	"%rd6", "%rd2");
+	DEFINE("cvta.global.u64", 	"%rd7", "%rd6");
+	DEFINE("cvta.to.global.u64", 	"%rd8", "%rd1");
+	DEFINE("cvta.global.u64", 	"%rd9", "%rd8");
+	DEFINE("st.u64", "[%SP+0]", "%rd9");
+	DEFINE("st.u64", "[%SP+8]", "%rd7");
+	DEFINE("st.u64", "[%SP+16]", "%rd5");
+	DEFINE("mov.u32", "%r1", "%ctaid.x");
+	DEFINE("mov.u32", "%r2", "%ntid.x");
+	DEFINE3("mul.lo.s32", "%r3", "%r1", "%r2");
+	DEFINE("mov.u32", "%r4", "%tid.x");
+	DEFINE3("add.s32", "%r5", "%r3", "%r4");
+	DEFINE("st.u32", "[%SP+24]", "%r5");
+	DEFINE("ld.u64", "%rd10", "[%SP+0]");
+	DEFINE("ld.u32", "%rd11", "[%SP+24]");
+	DEFINE3("shl.b64", "%rd12", "%rd11", "2");
+	DEFINE3("add.s64", "%rd13", "%rd10", "%rd12");;
+	DEFINE("ld.f32", 	"%f1", "[%rd13]");
+	DEFINE("ld.u64", 	"%rd14", "[%SP+8]");
+	DEFINE3("add.s64", "%rd15", "%rd14", "%rd12");
+	DEFINE("ld.f32", 	"%f2", "[%rd15]");
+	DEFINE3("add.rn.f32", "%f3", "%f1", "%f2");
+	DEFINE("ld.u64", 	"%rd16", "[%SP+16]");
+	DEFINE3("add.s64", "%rd17", "%rd16", "%rd12");
+	DEFINE("st.f32", 	"[%rd17]", "%f3");
   body.push_back(block);
   body.computeDefUseChain();
   PTXKernel kernel{"add", args, body};
@@ -29,10 +70,10 @@ TEST(RaiseToLLVMTest, SimpleKernel) {
     "target datalayout = \"e-i64:64-i128:128-v16:16-v32:32-n16:32:64\"\n"
     "target triple = \"nvptx-nvidia-cuda\"\n\n"
     "; Function Attrs: convergent mustprogress noinline norecurse nounwind optnone\n"
-    "define void @add() #0 {\n"
-    "  %1 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()\n"
-    "  %2 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()\n"
-    "  %3 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()\n"
+    "define void @add(ptr %0, ptr %1, ptr %2) #0 {\n"
+    "  %4 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()\n"
+    "  %5 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()\n"
+    "  %6 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()\n"
     "}\n\n"
     "; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn\n"
     "declare i32 @llvm.nvvm.read.ptx.sreg.ctaid.x() #1\n\n"


### PR DESCRIPTION
This patch adds an algorithm to determine the
type of the arguments of the original llvm function. The
idea is to traverse the graph in reverse propagating type
annotations all the way to the kernel arguments.

The test has been expanded to include most of the elementwise
add kernel. Also macros have been defined to simplify PTX definition
in the test.