### PR TITLE
This patch adds the ability to emit

### DIFF
--- a/include/conversion/RaiseToLLVM.h
+++ b/include/conversion/RaiseToLLVM.h
@@ -12,7 +12,10 @@ class PTXToLLVMConverter {
   PTXProgram &program;
   std::unique_ptr<PTXTypeInference> typeInferrer;
   void performTypeInference(PTXBasicBlock &block);
+  std::unordered_map<std::string_view, std::string_view> propagateKernelArgs(PTXKernel &kernel);
   llvm::Type *mapType(std::string_view str);
+  llvm::Value *findSourceFromClones(std::string_view name, std::unordered_map<std::string_view, std::string_view> &clones,
+                                    llvm::StringMap<llvm::Value *> &symbolTable);
 public:
   PTXToLLVMConverter(PTXProgram &program, llvm::LLVMContext &context);
   ~PTXToLLVMConverter() {}

--- a/include/conversion/TypeInference.h
+++ b/include/conversion/TypeInference.h
@@ -12,7 +12,7 @@ public:
   void doTypeInference(PTXControlFlowGraph &cfg);
   void constrainType(std::string_view name, std::string_view type);
   void applyConstraints(PTXInstruction &instr);
-  std::optional<std::string_view> getType(std::string_view symbol);
+  std::string_view getType(std::string_view symbol);
 private:
   llvm::LLVMContext &context;
   std::unordered_map<std::string_view, std::string_view> typeMap;

--- a/include/conversion/Utils.h
+++ b/include/conversion/Utils.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <vector>
+#include <string_view>
+
+namespace utils {
+
+std::vector<std::string_view> tokenize(std::string_view inst);
+std::string_view getPrefix(std::vector<std::string_view> &tokens);
+std::string_view getInstrType(std::vector<std::string_view> &tokens);
+bool isLoadInstruction(std::vector<std::string_view> &tokens);
+bool isStoreInstruction(std::vector<std::string_view> &tokens);
+bool isConvertInstruction(std::vector<std::string_view> &tokens);
+bool isBinaryInstruction(std::vector<std::string_view> &tokens);
+bool isMoveInstruction(std::vector<std::string_view> &tokens);
+bool isMulInstruction(std::vector<std::string_view> &tokens);
+std::string_view getAddress(std::string_view str);
+bool isDereference(std::string_view str);
+
+}

--- a/include/ir/PTXIR.h
+++ b/include/ir/PTXIR.h
@@ -42,9 +42,8 @@ public:
   size_t getNumOperands() const {
     return operands.size();
   }
-  std::optional<PTXOperand> getOperand(size_t idx) {
-    if (idx < operands.size()) return operands[idx];
-    return {};
+  PTXOperand getOperand(size_t idx) {
+    return operands[idx];
   }
   std::vector<PTXOperand> & getOperands() {
     return operands;
@@ -122,6 +121,12 @@ public:
   const std::vector<PTXBasicBlock> &getBlocks() const {
     return blocks;
   }
+  std::optional<std::shared_ptr<PTXValue>> lookup(std::string_view symbol) {
+    return symbolTable.lookup(symbol);
+  }
+  PTXSymbolTable &getSymbolTable() {
+    return symbolTable;
+  }
 };
 
 
@@ -133,14 +138,16 @@ public:
  */
 class PTXKernel {
   std::string_view name;
-  std::vector<PTXValue> arguments;
+  std::vector<std::shared_ptr<PTXValue>> arguments;
   PTXControlFlowGraph body;
 public:
-  PTXKernel(std::string_view name_, std::vector<PTXValue> &arguments_,
+  PTXKernel(std::string_view name_, std::vector<std::shared_ptr<PTXValue>> &arguments_,
             PTXControlFlowGraph &body_);
   std::string_view getName() const { return name; }
   PTXControlFlowGraph &getBody() { return body; }
-  std::vector<PTXValue> &getArguments() { return arguments; }
+  std::vector<std::shared_ptr<PTXValue>> &getArguments() { return arguments; }
+  size_t numArguments() const { return arguments.size(); }
+  std::shared_ptr<PTXValue> &getArgument(size_t i) { return arguments.at(i); }
 };
 
 

--- a/include/ir/SymbolTable.h
+++ b/include/ir/SymbolTable.h
@@ -2,8 +2,10 @@
 
 #include "ir/Value.h"
 #include <unordered_map>
+#include <string>
 #include <string_view>
 #include <optional>
+#include <iterator>
 
 /**
  * @class SymbolTable
@@ -11,7 +13,7 @@
  *
  */
 class PTXSymbolTable {
-  std::unordered_map<std::string_view, PTXValue> table;
+  std::unordered_map<std::string_view, std::shared_ptr<PTXValue>> table;
 public:
 
   PTXSymbolTable() {}
@@ -23,7 +25,7 @@ public:
    *
    * @param symbol : Symbol to be searched
    */
-  std::optional<PTXValue> lookup(std::string_view symbol) const {
+  std::optional<std::shared_ptr<PTXValue>> lookup(std::string_view symbol) const {
     if (table.contains(symbol)) {
       return table.at(symbol);
     }
@@ -37,7 +39,7 @@ public:
    * @param symbol : Symbol to be inserted into the table
    * @param value : Value corresponding to the symbol
    */
-  void insert(std::string_view symbol, PTXValue value) {
+  void insert(std::string_view symbol, std::shared_ptr<PTXValue> value) {
     table.emplace(std::make_pair(symbol, value));
   }
 

--- a/include/ir/Value.h
+++ b/include/ir/Value.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include <iostream>
 
 class PTXInstruction;
 
@@ -37,6 +38,9 @@ public:
   }
   std::vector<PTXInstruction *> &getUses() {
     return uses;
+  }
+  size_t getNumUses() const {
+    return uses.size();
   }
   void addDefiningInstruction(PTXInstruction *instr) {
     def = instr;

--- a/lib/conversion/CMakeLists.txt
+++ b/lib/conversion/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SRC
   RaiseToLLVM.cpp
   TypeInference.cpp
+  Utils.cpp
 )
 add_library(PTXToLLVMConversion ${SRC})
 target_link_libraries(PTXToLLVMConversion

--- a/lib/conversion/Utils.cpp
+++ b/lib/conversion/Utils.cpp
@@ -1,0 +1,87 @@
+#include "conversion/Utils.h"
+#include <cassert>
+
+namespace utils {
+
+std::vector<std::string_view> tokenize(std::string_view inst) {
+  std::vector<std::string_view> tokens;
+  size_t begin{0}, end{0};
+  for (size_t i = 0; i < inst.size(); i++) {
+    if (inst[i] == '.') {
+      end = i;
+      tokens.push_back(inst.substr(begin, end - begin));
+      begin = end + 1;
+    }
+    if (i == inst.size() - 1) {
+      tokens.push_back(inst.substr(begin, inst.size() -  begin));
+    }
+  }
+  return tokens;
+}
+
+std::string_view getPrefix(std::vector<std::string_view> &tokens) {
+  return tokens[0];
+}
+
+std::string_view getStateSpace(std::vector<std::string_view> &tokens) {
+  assert(tokens.size() >= 2);
+  std::vector<std::string_view> spaces{
+    "param", "global", "local", "shared", "const", "sreg", "reg"
+  };
+  for (auto space : spaces) {
+    if (tokens[1] == space)
+      return space;
+  }
+  return "generic";
+}
+
+// Assumes last token can be used to determine the type
+std::string_view getInstrType(std::vector<std::string_view> &tokens) {
+  return tokens.back();
+}
+
+std::string_view getInstrMode(std::vector<std::string_view> &tokens) {
+  // For instructions with 3 parts, return the middle token
+  if (tokens.size() == 3)
+    return tokens[1];
+  return "";
+}
+
+bool isMoveInstruction(std::vector<std::string_view> &tokens) {
+  return getPrefix(tokens) == "mov";
+}
+
+bool isMulInstruction(std::vector<std::string_view> &tokens) {
+  return getPrefix(tokens) == "mul";
+}
+
+bool isAddInstruction(std::vector<std::string_view> &tokens) {
+  return getPrefix(tokens) == "add";
+}
+
+bool isLoadInstruction(std::vector<std::string_view> &tokens) {
+  return getPrefix(tokens) == "ld";
+}
+
+bool isStoreInstruction(std::vector<std::string_view> &tokens) {
+  return getPrefix(tokens) == "st";
+}
+
+bool isConvertInstruction(std::vector<std::string_view> &tokens) {
+  return getPrefix(tokens) == "cvta";
+}
+
+bool isBinaryInstruction(std::vector<std::string_view> &tokens) {
+  auto prefix = getPrefix(tokens);
+  return ((prefix == "mul") || (prefix == "add") || (prefix == "shl"));
+}
+
+std::string_view getAddress(std::string_view str) {
+  return str.substr(1, str.size() - 2);
+}
+
+bool isDereference(std::string_view str) {
+  return (str[0] == '[') && (str.back() == ']');
+}
+
+}

--- a/lib/ir/PTXIR.cpp
+++ b/lib/ir/PTXIR.cpp
@@ -1,18 +1,19 @@
 #include "ir/PTXIR.h"
+#include "conversion/Utils.h"
 #include <iostream>
 
-PTXKernel::PTXKernel(std::string_view name_, std::vector<PTXValue> &arguments_,
+PTXKernel::PTXKernel(std::string_view name_, std::vector<std::shared_ptr<PTXValue>> &arguments_,
           PTXControlFlowGraph &body_) :
          name(name_), arguments(arguments_), body(body_) {}
 
 void PTXControlFlowGraph::computeDefUseChain() {
-  for (auto block : blocks) {
+  for (auto &block : blocks) {
     block.computeDefUseChain();
   }
 }
 
 void PTXBasicBlock::computeDefUseChain() {
-  for (auto inst : instructions) {
+  for (auto &inst : instructions) {
     computeDefUseChain(inst);
   }
 }
@@ -20,24 +21,25 @@ void PTXBasicBlock::computeDefUseChain() {
 void PTXBasicBlock::computeDefUseChain(PTXInstruction &inst) {
   if (!symbolTable)
     return;
-  int i = 0;
-  for (auto operand : inst.getOperands()) {
-    auto name = operand.getName();
+  for (size_t i = 0; i < inst.getNumOperands(); i++) {
+    auto name = inst.getOperand(i).getName();
+    if (utils::isDereference(name))
+      name = utils::getAddress(name);
     auto found = symbolTable->lookup(name);
-    PTXValue v;
-    if (!found) {
-      v = PTXValue(name, inst.getOperandType());
-    } else {
-      v = *found;
+    // If we found the symbol already, it cannot be a addDefiningInstruction
+    // and is just a use of the symbol
+    if (found) {
+      (*found)->addUse(&inst);
+      continue;
     }
+
+    auto v = std::make_shared<PTXValue>(name, inst.getOperandType());
     // TODO:Does this work for all PTX instructions?
     if (i == 0) {
-      v.addDefiningInstruction(&inst);
+      v->addDefiningInstruction(&inst);
     } else {
-      v.addUse(&inst);
+      v->addUse(&inst);
     }
-    if (!found)
-      symbolTable->insert(name, v);
-    i++;
+    symbolTable->insert(name, v);
   }
 }

--- a/test/conversion/RaiseToLLVM_test.cpp
+++ b/test/conversion/RaiseToLLVM_test.cpp
@@ -18,10 +18,10 @@
 TEST(RaiseToLLVMTest, SimpleKernel) {
   llvm::LLVMContext context;
   PTXProgram program("kernel");
-  std::vector<PTXValue> args;
-  args.push_back(PTXValue("_Z3addPKfS0_Pf_param_0", PTXType("u64")));
-  args.push_back(PTXValue("_Z3addPKfS0_Pf_param_1", PTXType("u64")));
-  args.push_back(PTXValue("_Z3addPKfS0_Pf_param_2", PTXType("u64")));
+  std::vector<std::shared_ptr<PTXValue>> args;
+  args.push_back(std::make_shared<PTXValue>("_Z3addPKfS0_Pf_param_0", PTXType("u64")));
+  args.push_back(std::make_shared<PTXValue>("_Z3addPKfS0_Pf_param_1", PTXType("u64")));
+  args.push_back(std::make_shared<PTXValue>("_Z3addPKfS0_Pf_param_2", PTXType("u64")));
   PTXControlFlowGraph body;
   PTXBasicBlock block;
 	DEFINE("mov.u64",	"%SPL", "__local_depot6");
@@ -71,9 +71,19 @@ TEST(RaiseToLLVMTest, SimpleKernel) {
     "target triple = \"nvptx-nvidia-cuda\"\n\n"
     "; Function Attrs: convergent mustprogress noinline norecurse nounwind optnone\n"
     "define void @add(ptr %0, ptr %1, ptr %2) #0 {\n"
-    "  %4 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()\n"
-    "  %5 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()\n"
-    "  %6 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()\n"
+    "  %4 = alloca ptr, align 8\n"
+    "  store ptr %0, ptr %4, align 8\n"
+    "  %5 = alloca ptr, align 8\n"
+    "  store ptr %1, ptr %5, align 8\n"
+    "  %6 = alloca ptr, align 8\n"
+    "  store ptr %2, ptr %6, align 8\n"
+    "  %7 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()\n"
+    "  %8 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()\n"
+    "  %9 = mul i32 %7, %8\n"
+    "  %10 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()\n"
+    "  %11 = add i32 %9, %10\n"
+    "  %12 = alloca i32, align 4\n"
+    "  store i32 %11, ptr %12, align 4\n"
     "}\n\n"
     "; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn\n"
     "declare i32 @llvm.nvvm.read.ptx.sreg.ctaid.x() #1\n\n"

--- a/test/ir/SymbolTable_test.cpp
+++ b/test/ir/SymbolTable_test.cpp
@@ -5,7 +5,7 @@ TEST(SymbolTableTest, AddEntry) {
   auto symTable = std::make_unique<PTXSymbolTable>();
   EXPECT_EQ(symTable->size(), 0);
   PTXType type("i8");
-  auto v = PTXValue("a", type);
+  auto v = std::make_shared<PTXValue>("a", type);
   symTable->insert("a", v);
   EXPECT_EQ(symTable->size(), 1);
 }
@@ -13,14 +13,14 @@ TEST(SymbolTableTest, AddEntry) {
 TEST(SymbolTableTest, LookupEntry) {
   auto symTable = std::make_unique<PTXSymbolTable>();
   PTXType type("i8");
-  auto v = PTXValue("a", type);
+  auto v = std::make_shared<PTXValue>("a", type);
   symTable->insert("a", v);
   auto shouldBeFound = symTable->lookup("a");
   if (!shouldBeFound) {
     FAIL() << "a should be in the symbol table!";
   }
   auto foundValue = *shouldBeFound;
-  EXPECT_EQ(foundValue.getSymbol(), v.getSymbol());
+  EXPECT_EQ(foundValue->getSymbol(), v->getSymbol());
   auto shouldNotBeFound = symTable->lookup("b");
   if (shouldNotBeFound) {
     FAIL() << "b should not be in the symbol table!";


### PR DESCRIPTION
store, add, mul and alloca instructions

When generating store instructions, we first
check whether the location where we are storing to exists.
If not an alloca is generated.

We also emit mul and add instructions when the source
and destination operands are 32 bits long.

To enable using the kernel args, we do analysis to propagate
the kernel arg values through the address space instructions
(cvta) which are not relevant for LLVM IR.

Finally, we refactor the code and move common functions to utils.